### PR TITLE
Allow custom keepalive timeouts

### DIFF
--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -25,7 +25,7 @@ server {
   <% end %>
 
   <% if ENV['KEEPALIVE_TIMEOUT'] %>
-  keepalive_timeout <%= ENV['KEEPALIVE_TIMEOUT'] %>
+  keepalive_timeout <%= ENV['KEEPALIVE_TIMEOUT'] %>;
   <% else %>
   keepalive_timeout 5;
   <% end %>

--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -24,7 +24,11 @@ server {
   listen 80;
   <% end %>
 
+  <% if ENV['KEEPALIVE_TIMEOUT'] %>
+  keepalive_timeout <%= ENV['KEEPALIVE_TIMEOUT'] %>
+  <% else %>
   keepalive_timeout 5;
+  <% end %>
 
   error_page 502 503 504 /50x.html;
   location /50x.html {


### PR DESCRIPTION
Allow the user to set a custom keepalive_timeout by using an environment variable.
