### PR TITLE
Allow custom keepalive timeout

### DIFF
--- a/templates/etc/nginx/sites-enabled/server.conf.erb
+++ b/templates/etc/nginx/sites-enabled/server.conf.erb
@@ -25,7 +25,7 @@ server {
   <% end %>
 
   <% if ENV['KEEPALIVE_TIMEOUT'] %>
-  keepalive_timeout <%= ENV['KEEPALIVE_TIMEOUT'] %>
+  keepalive_timeout <%= ENV['KEEPALIVE_TIMEOUT'] %>;
   <% else %>
   keepalive_timeout 5;
   <% end %>


### PR DESCRIPTION
Allow the user to set a custom keepalive timeout by setting an environment variable.
